### PR TITLE
The command line tool pep8 was renamed pycodestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This document is a collection of links to advice and best practice for maintaini
 
 * One conceptual group per repository (the conceptual group size/scope may vary between projects)
 * Don't commit things that can be regenerated from the code
-* Use pre-commit hooks for code-checking (e.g. [`pylint`](https://www.pylint.org/), [`pep8`](https://pypi.python.org/pypi/pep8) for Python; [Shellcheck](https://github.com/koalaman/shellcheck) may be useful for `bash` scripts)
+* Use pre-commit hooks for code-checking (e.g. [`pylint`](https://www.pylint.org/), [`pycodestyle` aka `pep8`](https://pypi.python.org/pypi/pep8) for Python; [Shellcheck](https://github.com/koalaman/shellcheck) may be useful for `bash` scripts)
 * Use continuous integration where appropriate (e.g. [`TravisCI`](https://travis-ci.org/))
 * Use code quality integration where appropriate (e.g. [`Landscape.io`](https://landscape.io/))
 * Use test coverage integration where appropriate (e.g. [`codecov.io`](https://codecov.io/gh))


### PR DESCRIPTION
This package used to be called ``pep8`` but was renamed to ``pycodestyle`` to reduce confusion. Further discussion can be found in the issue where Guido requested this change, https://github.com/PyCQA/pycodestyle/issues/466